### PR TITLE
Update nginx image version and add try_files directive to nginx.conf templates

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,7 +15,7 @@ services:
     tty: true
 
   nginx:
-    image: ${IMG_REGISTRY:-bybatkhuu}/nginx:2.1.0-240313
+    image: ${IMG_REGISTRY:-bybatkhuu}/nginx:2.1.1-240314
     depends_on:
       - certbot
     restart: unless-stopped

--- a/templates/nginx.conf/010.http.conf.template
+++ b/templates/nginx.conf/010.http.conf.template
@@ -37,7 +37,7 @@ server {
 	root /var/www/web/public;
 
 	location / {
-		try_files ${DOLLAR}uri ${DOLLAR}uri/ =404;
+		try_files ${DOLLAR}uri ${DOLLAR}uri.html ${DOLLAR}uri/ =404;
 	}
 
 	## Sub-path as static files:

--- a/templates/nginx.conf/010.https.self.conf.template
+++ b/templates/nginx.conf/010.https.self.conf.template
@@ -42,7 +42,7 @@ server {
 	root /var/www/web/public;
 
 	location / {
-		try_files ${DOLLAR}uri ${DOLLAR}uri/ =404;
+		try_files ${DOLLAR}uri ${DOLLAR}uri.html ${DOLLAR}uri/ =404;
 	}
 
 	## Sub-path as static files:

--- a/templates/nginx.conf/100.example.com_https.conf.template
+++ b/templates/nginx.conf/100.example.com_https.conf.template
@@ -45,7 +45,7 @@ server {
 	root /var/www/example.com/public;
 
 	location / {
-		try_files ${DOLLAR}uri ${DOLLAR}uri/ =404;
+		try_files ${DOLLAR}uri ${DOLLAR}uri.html ${DOLLAR}uri/ =404;
 	}
 
 	## Sub-path as static files:

--- a/templates/nginx.conf/100.example.com_https.lets.conf.template
+++ b/templates/nginx.conf/100.example.com_https.lets.conf.template
@@ -46,7 +46,7 @@ server {
 	root /var/www/example.com/public;
 
 	location / {
-		try_files ${DOLLAR}uri ${DOLLAR}uri/ =404;
+		try_files ${DOLLAR}uri ${DOLLAR}uri.html ${DOLLAR}uri/ =404;
 	}
 
 	## Sub-path as static files:


### PR DESCRIPTION
This pull request updates the nginx image version to 2.1.1-240314 and adds the try_files directive to the nginx.conf templates. This change ensures that when a file is requested, nginx will first try to serve the file with the same name and extension, then try to serve the file with the same name and .html extension, and finally fall back to a 404 error if the file is not found.