### PR TITLE
:arrow_up: Bump Nginx image version to '3.0.5-250528'

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -18,7 +18,7 @@ services:
     tty: true
 
   nginx:
-    image: bybatkhuu/nginx:3.0.4-250526
+    image: bybatkhuu/nginx:3.0.5-250528
     depends_on:
       - certbot
     restart: unless-stopped


### PR DESCRIPTION
This pull request includes a minor version update for the `nginx` service in the `compose.yml` file. The `nginx` image has been updated from version `3.0.4-250526` to `3.0.5-250528` to ensure the service uses the latest features and fixes.